### PR TITLE
Fix base path for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,21 @@ simple-ml-demo-1/
 - `npm run build` - Build for production
 - `npm run preview` - Preview production build
 
+## Deployment Notes
+
+This demo is published via GitHub Pages at
+<https://tashaskyup.github.io/simple-ml-demo-1/>. The Vite configuration
+uses `/simple-ml-demo-1/` as the default base path so built assets load
+correctly on that host. If you need to deploy the app under a different
+subfolder, override the base URL when building:
+
+```bash
+VITE_BASE_URL=/my-subfolder/ npm run build
+```
+
+Using `VITE_BASE_URL` ensures the generated asset paths match your
+deployment setup.
+
 ## Technology Stack
 
 - **Frontend**: React 19, TypeScript

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,9 +9,12 @@ export default defineConfig(({ mode }) => {
   // Provide a safe fallback for missing API key
   const safeApiKey = geminiApiKey || "API_KEY_NOT_CONFIGURED";
 
+  // Default base path for GitHub Pages deployment
+  const base = env.VITE_BASE_URL || "/simple-ml-demo-1/";
+
   return {
     plugins: [react()],
-    base: "/simple-ml-demo-1/",
+    base,
     define: {
       "process.env.API_KEY": JSON.stringify(safeApiKey),
       "process.env.GEMINI_API_KEY": JSON.stringify(safeApiKey),


### PR DESCRIPTION
## Summary
- clarify GitHub Pages deployment instructions
- default Vite base path to `/simple-ml-demo-1/`

## Testing
- `node test-app.cjs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6860e37a2a98832c842e360fdfe4635e