### PR TITLE
Fix worker training weight sync

### DIFF
--- a/hooks/useTFModel.ts
+++ b/hooks/useTFModel.ts
@@ -32,6 +32,11 @@ interface TrainingWorkerMessage {
   payload?: any;
 }
 
+interface SerializedWeight {
+  shape: number[];
+  data: number[];
+}
+
 interface TrainingWorkerResponse {
   type:
     | "TRAINING_PROGRESS"
@@ -39,7 +44,10 @@ interface TrainingWorkerResponse {
     | "TRAINING_ERROR"
     | "PREDICTION_RESULT"
     | "MODEL_READY";
-  payload?: any;
+  payload?: {
+    modelWeights?: SerializedWeight[];
+    [key: string]: any;
+  };
 }
 
 // Backend performance comparison
@@ -1090,6 +1098,9 @@ export const useTFModel = ({
 
           case "TRAINING_COMPLETE":
             console.log("Complete Training completed in worker");
+            if (payload && Array.isArray(payload.modelWeights)) {
+              loadModelWeights(payload.modelWeights);
+            }
             setStatus("success");
             setIsUsingBackgroundWorker(false);
             isUsingBackgroundWorkerRef.current = false;

--- a/hooks/useTrainingWorker.ts
+++ b/hooks/useTrainingWorker.ts
@@ -7,9 +7,17 @@ interface TrainingWorkerMessage {
   payload?: any;
 }
 
+interface SerializedWeight {
+  shape: number[];
+  data: number[];
+}
+
 interface TrainingWorkerResponse {
   type: 'TRAINING_PROGRESS' | 'TRAINING_COMPLETE' | 'TRAINING_ERROR' | 'PREDICTION_RESULT' | 'MODEL_READY';
-  payload?: any;
+  payload?: {
+    modelWeights?: SerializedWeight[];
+    [key: string]: any;
+  };
 }
 
 export interface TrainingProgress {
@@ -30,7 +38,7 @@ interface UseTrainingWorkerProps {
   layers: LayerConfig[];
   learningRate: number;
   onTrainingProgress?: (progress: TrainingProgress) => void;
-  onTrainingComplete?: (modelWeights: any[]) => void;
+  onTrainingComplete?: (modelWeights: SerializedWeight[]) => void;
   onPredictionResult?: (prediction: PredictionState) => void;
   onError?: (error: string) => void;
 }
@@ -82,7 +90,7 @@ export const useTrainingWorker = ({
             console.log('Complete Training completed in worker');
             setStatus("ready");
             setCurrentProgress(null);
-            onTrainingComplete?.(payload.modelWeights);
+            onTrainingComplete?.(payload.modelWeights || []);
             break;
 
           case 'PREDICTION_RESULT':


### PR DESCRIPTION
## Summary
- extend worker protocol to include serialized weight shapes
- send serialized weights when training completes
- update hook message types and apply worker-trained weights on completion

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module '@vitejs/plugin-react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6882fdb66c20832c912e480171e8d320